### PR TITLE
require node 10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
   directories:
   - node_modules
 node_js:
-- '8'
 - '10'
 - '12'
 - '13'

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ code using `eslint` (preferred) or `jshint`.
 
 ## Release History
 
+1.3.0: require node 10+
+
 1.2.7: update version info & package lock
 
 1.2.6: streamline dependencies- move lint outside of package/grunt; bump version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "text2datauri",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1597,9 +1597,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt": "1.0.4"
   },
   "engines": {
-    "node": ">8.0.0"
+    "node": ">10.0.0"
   },
   "homepage": "https://github.com/mobilemind/text2datauri",
   "keywords": [
@@ -34,5 +34,5 @@
   "scripts": {
     "test": "grunt test"
   },
-  "version": "1.2.7"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
* node 8 is no longer on LTS as of 12/31/2019
* require node 10+
* update lock file, .travis file, package.json version, & README.md
